### PR TITLE
fix: rangeZipPattern should recognize non-digit character

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ const textBlacklistUnderCountryHeader = [
   /Effective date:/,
   /^\s*$/
 ];
-const rangeZipPattern = /(.+) +- +(.+)/;
+const rangeZipPattern = /([A-Z0-9 ]+) +- +([A-Z0-9 ]+)/;
 
 // state
 let foundRemoteCountryHeader = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ const textBlacklistUnderCountryHeader = [
   /Effective date:/,
   /^\s*$/
 ];
-const rangeZipPattern = /([\d-]+) +- +([\d-]+)/;
+const rangeZipPattern = /(.+) +- +(.+)/;
 
 // state
 let foundRemoteCountryHeader = false;


### PR DESCRIPTION
some postal codes for `Canada` on the document are a range instead of exact zip code value.
e.g. `A0B 0C6 - A0B 0C9`
